### PR TITLE
RDKBACCL-975 : Provide command line args for iperf3 app

### DIFF
--- a/recipes-example/images/dac-image-iperf3.bb
+++ b/recipes-example/images/dac-image-iperf3.bb
@@ -11,5 +11,5 @@ APP_METADATA_PATH = "metadatas/iperf3-appmetadata.json"
 # optional
 OCI_IMAGE_AUTHOR = "rdkcentral"
 OCI_IMAGE_AUTHOR_EMAIL = "info@rdkcentral.com"
-OCI_IMAGE_ENTRYPOINT_ARGS = ""
+OCI_IMAGE_ENTRYPOINT_ARGS = "-c\@192.168.128.1\@-t\@60\@-b\@100M\@-P\@4"
 OCI_IMAGE_WORKINGDIR = "/" 


### PR DESCRIPTION
Reason for change: Assigning command line arguments to iperf3 oci bundle 
Test Procedure: UspPa -c operate "Device.SoftwareModules.InstallDU(URL=http://192.168.2.51/iperf3argsjul255.tar)" UspPa -c operate "Device.SoftwareModules.ExecutionUnit.1.SetRequestedState(RequestedState=Active)" 
Risks: None