### PR TITLE
RDKBACCL-976: integrate & build rdk-speedtest-cli with meta-dac-sdk-broadband & test with DAC

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -3,6 +3,7 @@ BBPATH .= ":${LAYERDIR}"
 
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "meta-dac"
@@ -27,14 +28,14 @@ RDK_RELEASE ?= "6.1"
 
 EXTRA_VERSIONS_PATH ?= "${TMPDIR}/versions"
 
-BBMASK += "/meta-rdk/"
-BBMASK += "/meta-cmf/(?!recipes-extended|recipes-devtools)"
+BBMASK += "/meta-rdk/(?!recipes-common/(telemetry|rbus|breakpad_wrapper|lib_syscall_wrapper|libunpriv|rdk-logger|webconfig-framework))"
+BBMASK += "/meta-cmf/(?!recipes-extended|recipes-common)"
 BBMASK += "/meta-cmf/recipes-extended/(?!rpcserver)"
-BBMASK += "/meta-cmf/recipes-devtools/"
-
-BBMASK += "/meta-rdk-ext/(?!recipes-devtools|recipes-extended|recipes-multimedia)"
+BBMASK += "/meta-cmf/recipes-common/(?!webconfig-framework)"
+BBMASK += "/meta-rdk-ext/(?!recipes-devtools|recipes-extended|recipes-multimedia|recipes-support)"
 BBMASK += "/meta-rdk-ext/recipes-extended/(?!graphite2|curl-netflix)"
 BBMASK += "/meta-rdk-ext/recipes-devtools/(?!dwarfutils)"
+BBMASK += "/meta-rdk-ext/recipes-support/(?!linenoise)"
 # cobalt-24 needs gstreamer 1.18 inside /meta-rdk-ext/recipes-multimedia/gstreamer
 # in other cases we use gstreamer 1.16 in meta-openembedded
 BBMASK += "${@bb.utils.contains('DISTRO_FEATURES', 'cobalt-24', '/meta-rdk-ext/recipes-multimedia/(?!gstreamer)', '/meta-rdk-ext/recipes-multimedia/', d)}"

--- a/recipes-common/lib_syscall_wrapper/libsyswrapper.bbappend
+++ b/recipes-common/lib_syscall_wrapper/libsyswrapper.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF_remove = "--disable-static "

--- a/recipes-common/rbus/rbus.bbappend
+++ b/recipes-common/rbus/rbus.bbappend
@@ -1,0 +1,1 @@
+CFLAGS_append = "-Wno-format-truncation -Wno-stringop-truncation -Wno-error=format-security "

--- a/recipes-common/telemetry/telemetry_git.bbappend
+++ b/recipes-common/telemetry/telemetry_git.bbappend
@@ -1,0 +1,2 @@
+CFLAGS += " -Wno-error=unused-result -Wno-error=stringop-truncation"
+DEPENDS += " webconfig-framework "

--- a/recipes-common/webconfig-framework/webconfig-framework.bbappend
+++ b/recipes-common/webconfig-framework/webconfig-framework.bbappend
@@ -1,0 +1,1 @@
+CFLAGS += " -Wno-error=unused-result -Wno-error=stringop-truncation"

--- a/recipes-example/example/speedtest/rdk-speedtest-cli_git.bb
+++ b/recipes-example/example/speedtest/rdk-speedtest-cli_git.bb
@@ -1,0 +1,34 @@
+SUMMARY = "RDK Speed Test CLI tool"
+DESCRIPTION = "Command line tool for running iperf3 speed tests and updating RDK diagnostic parameters"
+SECTION = "net"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "${CMF_GITHUB_ROOT}/rdk-speedtest-cli;protocol=https;nobranch=1"
+SRCREV = "f6a906305302aea3ebfd037b0a58f8ea54a9c9ae"
+PV = "1.0.0"
+CFLAGS_append += " -DRBUS_BUILD_INTEGRATED"
+CFLAGS_append += " -DRBUS_BUILD_FLAG_ENABLE"
+LDFLAGS_append = " -liperf -ltelemetry_msgsender -lrbus -lrtMessage -lrbuscore"
+
+S = "${WORKDIR}/git"
+
+inherit autotools ${@bb.utils.contains("DISTRO_FEATURES", "kirkstone", "python3native", "pythonnative", d)}
+
+DEPENDS = "iperf3 telemetry rbus"
+
+CFLAGS_append = " \
+    -I ${RECIPE_SYSROOT}/usr/include \
+    -I ${RECIPE_SYSROOT}/usr/include/rtmessage \
+    -I ${RECIPE_SYSROOT}/usr/include/rbus \
+    "
+
+do_compile() {
+        ${CC} ${S}/source/rdk-speedtest-cli.c ${CFLAGS} ${LDFLAGS} -I ${S}/include -o RefSpeedtestClient
+}
+
+
+do_install() {
+        install -d ${D}${bindir}
+        install -m 0755 RefSpeedtestClient ${D}${bindir}/RefSpeedtestClient
+}

--- a/recipes-example/images/dac-image-speedtest.bb
+++ b/recipes-example/images/dac-image-speedtest.bb
@@ -1,0 +1,22 @@
+SUMMARY = "DAC Container with SDL speedtest application"
+
+inherit  dac-image-base
+
+IMAGE_INSTALL = "rdk-speedtest-cli"
+
+# needed
+OCI_IMAGE_ENTRYPOINT = "/usr/bin/RefSpeedtestClient"
+APP_METADATA_PATH = "metadatas/speedtest-appmetadata.json"
+
+# optional
+OCI_IMAGE_AUTHOR = "rdkcentral"
+OCI_IMAGE_AUTHOR_EMAIL = "info@rdkcentral.com"
+OCI_IMAGE_ENTRYPOINT_ARGS = "192.168.128.1\@-p\@5201\@-t\@15\@-b\@200\@-P\@6"
+
+OCI_IMAGE_WORKINGDIR = "/"
+
+ROOTFS_POSTPROCESS_COMMAND += "remove_libstd_from_rootfs;"
+
+remove_libstd_from_rootfs() {
+    rm -f ${IMAGE_ROOTFS}/usr/lib/libstdc++.so.6
+}

--- a/recipes-example/images/metadatas/speedtest-appmetadata.json
+++ b/recipes-example/images/metadatas/speedtest-appmetadata.json
@@ -1,0 +1,17 @@
+{
+    "id": "com.rdk.speedtest",
+    "type": "application/vnd.rdk-app.dac.native",
+    "version": "1.0.0",
+    "description": "speedtest client test application",
+    "priority": "optional",
+    "graphics": false,
+    "network": {
+        "type": "open"
+    },
+    "storage": {},
+    "resources": {
+        "ram": "128M"
+    },
+    "features": [],
+    "mounts": []
+}


### PR DESCRIPTION
Reason for change: Building the speedtest cli with dac layer and running as a bundle
Test procedure: Test the bundle using usp-pa commands
Risks: Low